### PR TITLE
Add parens to support ESP-IDF under gcc 5.2.0 - with warnings as errors

### DIFF
--- a/src/EEPROM32_Rotate.cpp
+++ b/src/EEPROM32_Rotate.cpp
@@ -97,7 +97,7 @@ uint8_t EEPROM32_Rotate::add_by_subtype(uint8_t subtype) {
 
         count++;
 
-    } while (iterator = esp_partition_next(iterator));
+    } while ((iterator = esp_partition_next(iterator)));
 
     // Release the iterator
     esp_partition_iterator_release(iterator);


### PR DESCRIPTION
EEPROM32_Rotate.cpp:100:52: error: suggest parentheses around assignment used as truth value [-Werror=parentheses]
     } while (iterator = esp_partition_next(iterator));